### PR TITLE
Add support for custom user model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## (unreleased)
 
+* feature: Add support for custom user models
 
 ## 0.0.2 (2023-07-11)
 * fix: Added the Github project url to the setup.py file for PyPi linking

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ First install this package in your project
 pip install djangocms-4-migration
 ```
 
+## Configuration
+
+If you have a custom user model, you should designate a "migration user" by specifying the user ID in your settings like so:
+
+```
+CMS_MIGRATION_USER_ID = <user id>
+```
+
 ## Running
 Simply run the following command to run the data migration. 
 **Note:** This command calls the django migrate command, this is because it has to run commands that save information that would have been lost by running the cms migrations directly.

--- a/djangocms_4_migration/helpers.py
+++ b/djangocms_4_migration/helpers.py
@@ -1,9 +1,8 @@
 import logging
-import settings
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +14,8 @@ def get_or_create_migration_user(user_model=get_user_model()):
     This is the user that is used to automatically attach to new items created as
     part of the cms migration.
     """
+    if getattr(settings, "CMS_MIGRATION_USER_ID"):
+        return user_model.objects.get(id=settings.CMS_MIGRATION_USER_ID), False
     return user_model.objects.get_or_create(
         username='djangocms_4_migration_user',
         is_staff=True,

--- a/djangocms_4_migration/management/commands/migrate_alias_plugins.py
+++ b/djangocms_4_migration/management/commands/migrate_alias_plugins.py
@@ -2,8 +2,8 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
@@ -28,6 +28,8 @@ from djangocms_4_migration.models import PageData
 
 
 logger = logging.getLogger(__name__)
+
+User = get_user_model()
 
 src_alias_count = 0
 reference_alias_count = 0
@@ -206,7 +208,7 @@ def process_old_alias_sources(site, language, site_plugin_queryset):
         if is_versioning_enabled():
             from djangocms_versioning.models import Version
             # Create version
-            changed_by = User.objects.get(username=old_plugin.placeholder.source.changed_by)
+            changed_by = User.objects.get(**{User.USERNAME_FIELD: old_plugin.placeholder.source.changed_by})
             version = Version.objects.create(content=alias_content, created_by=changed_by)
             version.save()
             version.publish(changed_by)

--- a/djangocms_4_migration/migrations/0003_page_version_integration_data_migration.py
+++ b/djangocms_4_migration/migrations/0003_page_version_integration_data_migration.py
@@ -64,7 +64,7 @@ def forwards(apps, schema_editor):
         # Find the user
         try:
             created_by = User.objects.using(db_alias).get(
-                username=page_content.page.created_by
+                **{User.USERNAME_FIELD: page_content.page.created_by}
             )
         except:
             # Use the first super user as the author as a fall back


### PR DESCRIPTION
- Use `get_user_model` consistently
- Respect possibly changed username field
- Add ability to provide migration user ID via settings as creating a custom user might miss additional required fields

I also changed `import settings` to `from django.conf import settings` which seemed like what it should have been(?).