### PR TITLE
import settings from django.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## (unreleased)
+* fix: import `settings` from `django.conf` rather than from `PYTHONPATH`
 
 
 ## 0.0.2 (2023-07-11)

--- a/djangocms_4_migration/helpers.py
+++ b/djangocms_4_migration/helpers.py
@@ -1,5 +1,5 @@
 import logging
-import settings
+from django.conf import settings
 
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site


### PR DESCRIPTION
the `helpers.py` module imports the `settings` module that might not be available unless it's on the `PYTHONPATH`. the better way is to import it from `django.conf`.

see https://docs.djangoproject.com/en/5.0/topics/settings/#using-settings-in-python-code